### PR TITLE
Add CLI option to negate `--auto-sys-inc`

### DIFF
--- a/compile-db-gen.py
+++ b/compile-db-gen.py
@@ -344,6 +344,11 @@ def add_common_opts_parse(s):
                    default=True,
                    action="store_true",
                    help="auto detect the system include path")
+    s.add_argument("--no-auto-sys-inc",
+                   "-A",
+                   action="store_false",
+                   dest="auto_sys_inc",
+                   help="don't auto detect the system include path")
     s.add_argument("--include",
                    "-i",
                    metavar="REGEX",


### PR DESCRIPTION
`--auto-sys-inc` is a nice feature, but there is no way to turn it off. Usually it is OK, when it is on, but sometimes it does not work properly and the whole script fails because of it. For example, I experienced such failures with a peculiar build system which changes `PATH` mid-build, so that compiler *is* in `PATH` when invoked *during the build*, but *is no longer* in the `PATH` when `compile-db-gen` wants to extract system includes.