### PR TITLE
Improve speed and reliability

### DIFF
--- a/compile-db-gen.py
+++ b/compile-db-gen.py
@@ -91,10 +91,10 @@ class OType:
 
 chdir_re = re.compile(r"^(\d+) +chdir\((.*)(\)\s+= 0|<unfinished \.\.\.>)")
 exec_re = re.compile(r"^(\d+) +execve\((.*)(\)\s*= 0|<unfinished \.\.\.>)")
-exit_re = re.compile(r"^(\d+) \+\+\+ (?:exited with|killed by) ")
-fork_re = re.compile(r"^(\d+) v?fork\((?:\) += (\d+)| <unfinished \.\.\.>)$")
-fork_resumed_re = re.compile(r"^(\d+) <\.\.\. v?fork resumed>\) += (\d+)$")
-clone_re = re.compile(r"^(\d+) clone3?\(.*(?:\) = (\d+)| <unfinished \.\.\.>)$")
+exit_re = re.compile(r"^(\d+) +\+\+\+ (?:exited with|killed by) ")
+fork_re = re.compile(r"^(\d+) +v?fork\((?:\) += (\d+)| <unfinished \.\.\.>)$")
+fork_resumed_re = re.compile(r"^(\d+) +<\.\.\. v?fork resumed>\) += (\d+)$")
+clone_re = re.compile(r"^(\d+) +clone3?\(.*(?:\) = (\d+)| <unfinished \.\.\.>)$")
 child_re = re.compile(r"^(?:, child_tidptr=.*)?\) += (\d+)$")
 ccache_re = re.compile(r'^([^/]*/)*([^-]*-)*ccache(-\d+(\.\d+){0,2})?$')
 
@@ -226,7 +226,7 @@ proc_run[pid] = {
             # first ocurr in the lines, it's new child process, get the dir
             # try to find the child end log to get its parent
             ppid = parent.get(pid)
-            assert ppid is not None or not proc_run
+            assert ppid is not None or not proc_run, f"{ppid} {pid} {proc_run} {parent}"
             cwd = proc_run[ppid]['cwd'] if ppid in proc_run else ppwd
             proc_run[pid] = {"cwd": cwd,
                              "child": [],

--- a/compile-db-gen.py
+++ b/compile-db-gen.py
@@ -93,6 +93,7 @@ chdir_re = re.compile(r"^(\d+) +chdir\((.*)(\)\s+= 0|<unfinished \.\.\.>)")
 exec_re = re.compile(r"^(\d+) +execve\((.*)(\)\s*= 0|<unfinished \.\.\.>)")
 exit_re = re.compile(r"^(\d+) \+\+\+ (?:exited with|killed by) ")
 fork_re = re.compile(r"^(\d+) v?fork\((?:\) += (\d+)| <unfinished \.\.\.>)$")
+fork_resumed_re = re.compile(r"^(\d+) <\.\.\. v?fork resumed>\) += (\d+)$")
 clone_re = re.compile(r"^(\d+) clone3?\(.*(?:\) = (\d+)| <unfinished \.\.\.>)$")
 child_re = re.compile(r"^(?:, child_tidptr=.*)?\) += (\d+)$")
 ccache_re = re.compile(r'^([^/]*/)*([^-]*-)*ccache(-\d+(\.\d+){0,2})?$')
@@ -126,6 +127,14 @@ def genlineobjs(fname):
                     parent[cid] = pid
                 else:
                     unfinished_fork = True
+                continue
+
+            m = fork_resumed_re.match(line)
+            if m:
+                assert unfinished_fork
+                pid, cid = m.group(1, 2)
+                parent[cid] = pid
+                unfinished_fork = False
                 continue
 
             m = clone_re.match(line)


### PR DESCRIPTION
These changes cover two issues:
1. It is not reliable to associate child process with a parent based on parent getting a `SIGCHLD`. (I guess parent process may terminate before the child.) `clone()`/`fork()`/`vfork()` syscalls are used instead.
1. `get_parent_pid()` has O(N) complexity and given that it is called O(N) times the whole thing has O(N<sup>2</sup>) complexity making this tool almost unusable for large projects. Using a dictionary for parent pid lookup increases processing speed dramatically.